### PR TITLE
Parametric-free struct helper

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -176,6 +176,12 @@ version = "0.9.3"
 deps = ["Libdl", "LinearAlgebra", "Serialization", "SparseArrays"]
 uuid = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 
+[[SyntaxTree]]
+deps = ["Test"]
+git-tree-sha1 = "9f33aae2c72d812968a6b7af9e189aa925661a99"
+uuid = "a4af3ec5-f8ac-5fed-a759-c2e80b4d74cb"
+version = "1.0.1"
+
 [[Test]]
 deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+SyntaxTree = "a4af3ec5-f8ac-5fed-a759-c2e80b4d74cb"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]

--- a/src/free_params.jl
+++ b/src/free_params.jl
@@ -1,5 +1,10 @@
-export FreeParameter
-export extract_free_parameters
+using SyntaxTree
+
+export FreeParameter, @FreeParameter
+
+export generic_type,
+       extract_free_parameters,
+       parametric_type
 
 const FPTYPES = Real
 
@@ -8,7 +13,7 @@ const FPTYPES = Real
 
 Free parameter of type `T` and prior `P`.
 """
-struct FreeParameter{T,P,B} <: FPTYPES
+mutable struct FreeParameter{T,P,B} <: FPTYPES
   "Value used in the model"
   val::T
   "prior distribution"
@@ -23,17 +28,9 @@ struct FreeParameter{T,P,B} <: FPTYPES
   end
 end
 
-Base.promote(x::T, fp::FreeParameter) where {T} = Base.promote(x, fp.val)
-Base.promote(fp::FreeParameter, x::T) where {T} = Base.promote(fp.val, x)
-
-Base.:+(x::FreeParameter, y::FPTYPES) = +(promote(x,y)...)
-Base.:-(x::FreeParameter, y::FPTYPES) = -(promote(x,y)...)
-Base.:*(x::FreeParameter, y::FPTYPES) = *(promote(x,y)...)
-Base.:/(x::FreeParameter, y::FPTYPES) = /(promote(x,y)...)
-Base.:+(x::FPTYPES, y::FreeParameter) = +(promote(x,y)...)
-Base.:-(x::FPTYPES, y::FreeParameter) = -(promote(x,y)...)
-Base.:*(x::FPTYPES, y::FreeParameter) = *(promote(x,y)...)
-Base.:/(x::FPTYPES, y::FreeParameter) = /(promote(x,y)...)
+#####
+##### Extracting free parameters
+#####
 
 """
     extract_free_parameters!(fp::Vector{FreeParameter}, s)
@@ -57,4 +54,183 @@ function extract_free_parameters(s)
   fp = FreeParameter[]
   extract_free_parameters!(fp, s)
   return fp
+end
+
+#####
+##### Generating generic data structures
+#####
+
+"""
+    get_type(s, fns)
+
+Expression of definition of
+struct `s` with fieldnames `fns`
+"""
+function get_type(s, fns)
+  expr = quote mutable struct $(s) end end
+  a = expr.args[2].args[3].args
+  for fn in fns
+    push!(a, fn, LineNumberNode)
+  end
+  return expr
+end
+
+"""
+    strip_type(T)
+
+Removes, for example, `Main.MyMod` from `Main.MyMod.Foo`
+
+# TODO: must be a better way, AST?
+"""
+strip_type(T) = Symbol(last(split(string(Symbol(T)),".")))
+
+"""
+    define_type(_module::Module, Tname, fns)
+
+Define struct `s` with fieldnames `fns`
+in module `_module`.
+"""
+function define_type(_module::Module, Tname, fns)
+  s_mod = strip_type(Tname) # remove prepending module
+  e = get_type(s_mod, fns)
+  _module.eval(e.args[2])
+end
+
+"""
+    define_generic_type(_module::Module, s::T) where {T}
+
+Define struct `s` in module `_module`
+_without_ parameters.
+"""
+function define_generic_type(_module::Module, s::T) where {T}
+  if !isprimitivetype(T)
+    fns = fieldnames(T)
+    define_type(_module, T.name, fns)
+    for fn in fns
+      prop = getproperty(s, fn)
+      define_generic_type(_module, prop)
+    end
+  end
+  return nothing
+end
+
+"""
+    get_type_instance(T, fields; strip_module=true)
+
+Expression of instance of type `T` with fields `fields`
+"""
+function get_type_instance(T, fields; strip_module=true)
+  T_mod = T
+  strip_module && (T_mod = strip_type(T)) # remove prepending module
+  expr = quote $(T_mod)() end |> SyntaxTree.linefilter!
+  a = expr.args[1].args
+  for field in fields
+    push!(a, field)
+  end
+  return expr
+end
+
+"""
+    _generic_type(_module::Module, s::T) where {T}
+
+Instance of generic struct in module
+`_module` that matches the structure
+of the parametric struct `s`.
+"""
+function _generic_type(_module::Module, s::T) where {T}
+  if !isprimitivetype(T)
+    fns = fieldnames(T)
+    props = [_generic_type(_module, prop) for prop in getproperty.(Ref(s), fns)]
+    e = get_type_instance(T.name, props)
+    return _module.eval(e)
+  else
+    return s
+  end
+end
+
+"""
+    generic_type(_module::Module, s)
+
+Define and instantiate generic struct in
+module `_module` that matches the structure
+of the parametric struct `s`.
+"""
+function generic_type(_module::Module, s)
+  define_generic_type(_module, s)
+  return _generic_type(_module, s)
+end
+
+#####
+##### Annotating free parameters
+#####
+
+macro FreeParameter(s, prior=nothing, bounds=nothing)
+  e = :($(s) = FreeParameter($(s), $(prior), $(bounds)))
+  return :($(esc(e)))
+end
+
+#####
+##### Generating parametric data structures
+#####
+
+"""
+    get_val(x)
+
+Gets value of `FreeParameter`,
+otherwise return identity.
+"""
+function get_val end
+get_val(x) = x
+get_val(x::FreeParameter) = x.val
+
+"""
+    map_struct_recursive!(f::F, s::T) where {T,F}
+
+Apply function `f` to properties
+of mutable struct `s` recursively.
+
+If `T isa FreeParameter`, skip to avoid
+assumptions on its properties.
+"""
+function map_struct_recursive!(f::F, s::T) where {F,T}
+  for fn in fieldnames(T)
+    prop = getproperty(s, fn)
+    setproperty!(s, fn, f(prop))
+    map_struct_recursive!(f, prop)
+  end
+end
+map_struct_recursive!(f::F, s::T) where {F,T<:FreeParameter} = nothing
+
+
+"""
+    _parametric_type(_module::Module, s::T, sg::TG) where {T,TG}
+
+Instance of parametric type `T`, defined in module
+`_module`, from generic struct `sg`.
+"""
+function _parametric_type(_module::Module, s::T, sg::TG) where {T,TG}
+  if !isprimitivetype(T)
+    props_old = getproperty.(Ref(s), fieldnames(T))
+    gprops = getproperty.(Ref(sg), fieldnames(TG))
+    Z = zip(props_old, gprops)
+    props_new = [_parametric_type(_module, prop, gprop) for (prop,gprop) in Z]
+    e = get_type_instance(T,props_new;strip_module=false)
+    return _module.eval(e)
+  else
+    return sg
+  end
+end
+
+"""
+    parametric_type(_module::Module, s::T, sg::TG) where {T,TG}
+
+Instance of parametric type `T`, defined in module
+`_module`, from generic struct `sg`.
+
+First, get values from `FreeParameter`'s.
+"""
+function parametric_type(_module::Module, s::T, sg::TG) where {T,TG}
+  tmp = deepcopy(sg)
+  map_struct_recursive!(get_val, tmp)
+  return _parametric_type(_module, s, tmp)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,34 +22,118 @@ const ∞ =  Inf
 
 end
 
-@testset "Constructor / promote" begin
-  fp = FreeParameter(5.0)
-  @show promote(1,fp)
-  @show promote(fp,1)
+"""
+    Params
+
+Stores model struct without parametric types.
+"""
+module Params end
+
+"""
+    Model
+
+module for model.
+"""
+module Model
+struct Bar{FT,I}
+  x::FT
+  i::I
+end
+struct Foo{FT,I}
+  x::FT
+  a::Bar{FT,I}
+end
+FT = Float64
+m = Foo(3.0, Bar(1.0, 2))
 end
 
-@testset "Extract parameters" begin
+"""
+    update_free_parameters!(fp, val)
 
-  mutable struct Bar{FT}
-    c::FreeParameter{FT}
-    d::FT
+Update free parameters vector `fp` with value `val`
+"""
+function update_free_parameters!(fp, val)
+  for i in eachindex(fp)
+    fp[i].val = typeof(fp[i].val)(val)
   end
-
-  mutable struct Foo{FT}
-    a::FreeParameter{FT}
-    b::Bar{FT}
-  end
-
-  FT = Float64
-  b = Bar{FT}(FreeParameter(1.0), 2.0)
-  f = Foo(FreeParameter(3.0), b)
-
-  fp = extract_free_parameters(f)
-  @test fp[1] + 1.0 ≈ fp[1].val + 1.0
-  @test fp[2] + 1.0 ≈ fp[2].val + 1.0
-
-  # # f is now updated
-  @test f.a + 1.0 ≈ f.a.val + 1.0
-  @test f.b.c + 1.0 ≈ f.b.c.val + 1.0
-
+  return nothing
 end
+
+@testset "Update free parameters in Params" begin
+  # Define parametric model
+  pmodel = Model.m
+
+  # Define a generic model in Params and get an instance
+  gmodel = generic_type(Params, pmodel)
+
+  # Test the generic model matches the parametric model
+  @test gmodel.x   ≈  pmodel.x
+  @test gmodel.a.x ≈  pmodel.a.x
+  @test gmodel.a.i == pmodel.a.i
+
+  # Annotate which parameters are `FreeParameter`'s
+  @FreeParameter(gmodel.x, Distributions.Normal)
+  @FreeParameter(gmodel.a.x)
+  @FreeParameter(gmodel.a.i)
+
+  # Extract pointers to `FreeParameter`'s
+  fp = extract_free_parameters(gmodel)
+
+  # Test free parameters match their annotated values
+  @test fp[1].prior == Distributions.Normal
+  @test fp[1].val ≈ 3.0
+  @test fp[2].val ≈ 1.0
+  @test fp[3].val == 2
+
+  # Update free parameters (in UQ)
+  new_params_val = 10.0
+  update_free_parameters!(fp, new_params_val)
+
+  # Get parametric version of updated generic model
+  gmodel_new = parametric_type(Model, pmodel, gmodel)
+
+  # Test model is updated
+  @test gmodel_new.x   ≈  new_params_val
+  @test gmodel_new.a.x ≈  new_params_val
+  @test gmodel_new.a.i == new_params_val
+end
+
+@testset "Update free parameters in Main" begin
+  # Define parametric model
+  pmodel = Model.m
+
+  # Define a generic model in Main and get an instance
+  gmodel = generic_type(Main, pmodel)
+
+  # Test the generic model matches the parametric model
+  @test gmodel.x   ≈  pmodel.x
+  @test gmodel.a.x ≈  pmodel.a.x
+  @test gmodel.a.i == pmodel.a.i
+
+  # Annotate which parameters are `FreeParameter`'s
+  @FreeParameter(gmodel.x, Distributions.Normal)
+  @FreeParameter(gmodel.a.x)
+  @FreeParameter(gmodel.a.i)
+
+  # Extract pointers to `FreeParameter`'s
+  fp = extract_free_parameters(gmodel)
+
+  # Test free parameters match their annotated values
+  @test fp[1].prior == Distributions.Normal
+  @test fp[1].val ≈ 3.0
+  @test fp[2].val ≈ 1.0
+  @test fp[3].val == 2
+
+  # Update free parameters (in UQ)
+  new_params_val = 10.0
+  update_free_parameters!(fp, new_params_val)
+
+  # Get parametric version of updated generic model
+  gmodel_new = parametric_type(Model, pmodel, gmodel)
+
+  # Test model is updated
+  @test gmodel_new.x   ≈  new_params_val
+  @test gmodel_new.a.x ≈  new_params_val
+  @test gmodel_new.a.i == new_params_val
+end
+


### PR DESCRIPTION
Implements functions for extracting free parameters with the following framework:

 - Define a generic and mutable struct `GMS` (stripped of parametric types) of a given struct `S` (e.g., a physics model)
 - Annotate `GMS` with `FreeParameter`'s
 - Extract a vector of free parameters `fp` from `GMS`
 - Update `fp` (in UQ)
 - Update `GMS` given `fp`
 - Create a new `S` given `GMS`